### PR TITLE
Extend list of claims used to extract user id from token

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ public Article UpdateArticle([FromRoute] string id, [FromBody] Article article)
 ## How it works
 
 For each request, the middleware does:
-* Extract the user ID from the *JWT* token `NameIdentifier` claim (overridable)
+* Extract the user ID from the *JWT* token claims (overridable)
+  * The following claim types are checked in exact order `Sub`, `NameIdentifier`, `FullyQualifiedId`, `ObjectIdentifier`
 * Extract `action` and `resourceType` from the `Permit` attribute
   * Multiple attributes are run sequentially. Controller first, then action
 * Use the `HttpClientFactory` to get a `HttpClient` and call the PDP's `/allowed` endpoint 

--- a/src/PermitMiddleware.cs
+++ b/src/PermitMiddleware.cs
@@ -106,7 +106,7 @@ public sealed class PermitMiddleware
             return await serviceProvider.GetProviderUserKey(httpContext, _options.GlobalUserKeyProviderType);
         }
 
-        var userId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var userId = ExtractUserId(httpContext);
         if (userId == null)
         {
             return null;
@@ -116,6 +116,25 @@ public sealed class PermitMiddleware
         var lastName = httpContext.User.FindFirst(ClaimTypes.Surname)?.Value ?? string.Empty;
         var email = httpContext.User.FindFirst(ClaimTypes.Email)?.Value ?? string.Empty;
         return new User(null, email, firstName, userId, lastName);
+    }
+
+    private static string? ExtractUserId(HttpContext httpContext)
+    {
+        var userId = httpContext.User.FindFirst(UserIdClaimTypes.Subject)?.Value;
+        if (userId != null)
+            return userId;
+
+        userId = httpContext.User.FindFirst(UserIdClaimTypes.NameIdentifier)?.Value;
+        if (userId != null)
+            return userId;
+
+        userId = httpContext.User.FindFirst(UserIdClaimTypes.FullyQualifiedId)?.Value;
+        if (userId != null)
+            return userId;
+
+        userId = httpContext.User.FindFirst(UserIdClaimTypes.ObjectIdentifier)?.Value;
+
+        return userId;
     }
 
     private async Task<bool> IsAuthorizedAsync(HttpContext httpContext,

--- a/src/PermitSDK.AspNet.csproj
+++ b/src/PermitSDK.AspNet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -9,6 +9,8 @@
         <WarningsAsErrors>$(WarningsAsErrors);1591</WarningsAsErrors>
         <Authors>Matteo Bortolazzo</Authors>
         <RepositoryUrl>https://github.com/permitio/permit-aspnet</RepositoryUrl>
+	    <Version>1.0.1</Version>
+	    <PackageReleaseNotes>Extend list of claims used to extract user id from token</PackageReleaseNotes>
 
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/UserIdClaimTypes.cs
+++ b/src/UserIdClaimTypes.cs
@@ -1,0 +1,29 @@
+﻿using System.Security.Claims;
+
+namespace PermitSDK.AspNet;
+
+/// <summary>
+/// Provides constants for claim types used to extract user ID.
+/// </summary>
+public static class UserIdClaimTypes
+{
+    /// <summary>
+    /// Represents the name identifier claim type.
+    /// </summary>
+    public const string NameIdentifier = ClaimTypes.NameIdentifier;
+
+    /// <summary>
+    /// Represents the object identifier claim type.
+    /// </summary>
+    public const string ObjectIdentifier = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+
+    /// <summary>
+    /// Represents the fully qualified ID claim type.
+    /// </summary>
+    public const string FullyQualifiedId = "fully_qualified_id";
+
+    /// <summary>
+    /// Represents the subject claim type.
+    /// </summary>
+    public const string Subject = "sub";
+}


### PR DESCRIPTION
Previous implementation would only try to obtain the user id from the NameIdentifier claim.
This is not always the case so we have extended to check additional claim types in order of importance and pick the first one that has a value populated.