### PR TITLE
Permit middleware - Fix single instance of ResourceInputBuilder

### DIFF
--- a/src/PermitExtensions.cs
+++ b/src/PermitExtensions.cs
@@ -30,7 +30,7 @@ public static class PermitExtensions
         configureOptions?.Invoke(options);
         return services.AddPermit(options);
     }
-    
+
     /// <summary>
     /// Register the Permit middleware.
     /// </summary>
@@ -46,7 +46,7 @@ public static class PermitExtensions
         {
             throw new InvalidOperationException("API key not set.");
         }
-        
+
         services
             .AddSingleton(options)
             .AddHttpClient<PdpService>(client =>
@@ -74,21 +74,22 @@ public static class PermitExtensions
         }
 
 
-		Func<IResourceInputBuilder> resourceInputBuilderFactory = () => new ResourceInputBuilder(options, applicationBuilder.ApplicationServices);
-		var pdp = applicationBuilder.ApplicationServices.GetService<PdpService>();
+        Func<IResourceInputBuilder> resourceInputBuilderFactory =
+            () => new ResourceInputBuilder(options, applicationBuilder.ApplicationServices);
+        var pdp = applicationBuilder.ApplicationServices.GetService<PdpService>();
         var logger = applicationBuilder.ApplicationServices.GetService<ILogger<PermitMiddleware>>();
-        
+
         return applicationBuilder.UseMiddleware<PermitMiddleware>(
             pdp, resourceInputBuilderFactory, options, logger);
     }
-    
+
     internal static Task<User?> GetProviderUserKey(this IServiceProvider serviceProvider,
         HttpContext httpContext, Type providerType)
-    { 
+    {
         return serviceProvider.RunProviderAsync<IPermitUserKeyProvider, User>(
             providerType, provider => provider.GetUserKeyAsync(httpContext));
     }
-    
+
     internal static Task<string?> GetProviderValue(this IServiceProvider serviceProvider,
         HttpContext httpContext, Type providerType)
     {
@@ -102,7 +103,7 @@ public static class PermitExtensions
         return serviceProvider.RunProviderAsync<IPermitValuesProvider, Dictionary<string, object>>(
             providerType, provider => provider.GetValues(httpContext));
     }
-    
+
     private static async Task<TResult?> RunProviderAsync<TProvider, TResult>(
         this IServiceProvider serviceProvider,
         Type providerType,

--- a/src/PermitExtensions.cs
+++ b/src/PermitExtensions.cs
@@ -74,13 +74,12 @@ public static class PermitExtensions
         }
 
 
-        IResourceInputBuilder resourceInputBuilder = new ResourceInputBuilder(
-            options, applicationBuilder.ApplicationServices);
-        var pdp = applicationBuilder.ApplicationServices.GetService<PdpService>();
+		Func<IResourceInputBuilder> resourceInputBuilderFactory = () => new ResourceInputBuilder(options, applicationBuilder.ApplicationServices);
+		var pdp = applicationBuilder.ApplicationServices.GetService<PdpService>();
         var logger = applicationBuilder.ApplicationServices.GetService<ILogger<PermitMiddleware>>();
         
         return applicationBuilder.UseMiddleware<PermitMiddleware>(
-            pdp, resourceInputBuilder, options, logger);
+            pdp, resourceInputBuilderFactory, options, logger);
     }
     
     internal static Task<User?> GetProviderUserKey(this IServiceProvider serviceProvider,

--- a/src/PermitMiddleware.cs
+++ b/src/PermitMiddleware.cs
@@ -16,8 +16,8 @@ public sealed class PermitMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly PdpService _pdpService;
-	private readonly Func<IResourceInputBuilder> _resourceInputBuilderFactory;
-	private readonly PermitOptions _options;
+    private readonly Func<IResourceInputBuilder> _resourceInputBuilderFactory;
+    private readonly PermitOptions _options;
     private readonly ILogger<PermitMiddleware> _logger;
 
     /// <summary>
@@ -31,8 +31,8 @@ public sealed class PermitMiddleware
     public PermitMiddleware(
         RequestDelegate next,
         PdpService pdpService,
-		Func<IResourceInputBuilder> resourceInputBuilderFactory,
-		PermitOptions options,
+        Func<IResourceInputBuilder> resourceInputBuilderFactory,
+        PermitOptions options,
         ILogger<PermitMiddleware> logger)
     {
         _next = next;
@@ -41,7 +41,7 @@ public sealed class PermitMiddleware
         _options = options;
         _logger = logger;
     }
-    
+
     /// <summary>
     /// Invoke the middleware
     /// </summary>
@@ -65,7 +65,7 @@ public sealed class PermitMiddleware
             await _next(httpContext);
             return;
         }
-        
+
         var permitMedata = GetPermitEndpointMetadata(endpoint);
         foreach (var data in permitMedata)
         {
@@ -146,18 +146,19 @@ public sealed class PermitMiddleware
         }
 
         var resourceInputBuilder = _resourceInputBuilderFactory();
-		var resourceInput = await resourceInputBuilder.BuildAsync(data, httpContext);
-        
+        var resourceInput = await resourceInputBuilder.BuildAsync(data, httpContext);
+
         // Call PDP
         var request = new AuthorizationQuery(data.Action, null, resourceInput, null, userKey);
         var response = await _pdpService.AllowedAsync(request);
-        if (response?.Debug is JsonElement debugNode && 
+        if (response?.Debug is JsonElement debugNode &&
             debugNode.TryGetProperty("rbac", out var rbacNode) &&
             rbacNode.TryGetProperty("reason", out var reasonNode))
         {
             var reason = reasonNode.GetString();
             _logger.LogDebug("RBAC reason: {Reason}", reason); // response.Debug.Rbac.Reason);
         }
+
         return response?.Allow ?? false;
     }
 }

--- a/src/PermitSDK.AspNet.csproj
+++ b/src/PermitSDK.AspNet.csproj
@@ -9,8 +9,8 @@
         <WarningsAsErrors>$(WarningsAsErrors);1591</WarningsAsErrors>
         <Authors>Matteo Bortolazzo</Authors>
         <RepositoryUrl>https://github.com/permitio/permit-aspnet</RepositoryUrl>
-	    <Version>1.0.1</Version>
-	    <PackageReleaseNotes>Extend list of claims used to extract user id from token</PackageReleaseNotes>
+	    <Version>1.0.2</Version>
+	    <PackageReleaseNotes>Permit middleware - Fix single instance of ResourceInputBuilder</PackageReleaseNotes>
 
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/tests/PermitSDK.AspNet.Tests/PermitMiddlewareTests.cs
+++ b/tests/PermitSDK.AspNet.Tests/PermitMiddlewareTests.cs
@@ -83,7 +83,7 @@ public class PermitMiddlewareTests
     [Fact]
     public async Task ActionOnResource_403()
     {
-        //Arrange
+        // Arrange
         var pdpService = GetPdpServiceFromAllowed(DefaultUserKey, TestAction, TestResourceType, null, false);
 
         var resourceInputBuilderFactoryMock = new Mock<Func<IResourceInputBuilder>>();


### PR DESCRIPTION
**Flow :** Generating request for pdpService, AllowedAsync Call.
**Issue :** "_isFailed" property of"ResourceInputBuilder" , maintains its value on every service call. Scenario where in its failed once , its failed on next consecutive calls
**Fix:**  Handle the issue by creating an instance of IResourceInputBuilder by invoking the _resourceInputBuilderFactory delegate. Then, it calls the BuildAsync method on the resourceInputBuilder instance to build a resource input using the data and httpContext parameters.


