### PR TITLE
ResourceFromBody-Fix issue of request body not accessible post reading data from httpContext.Request.Body using a StreamReader

### DIFF
--- a/src/PermitMiddleware.cs
+++ b/src/PermitMiddleware.cs
@@ -57,8 +57,11 @@ public sealed class PermitMiddleware
             return;
         }
 
-        // Get user key
-        var userKey = await GetUserKeyAsync(httpContext, serviceProvider);
+        //With an intention to read request multiple times, enable buffering
+        httpContext.Request.EnableBuffering();
+
+		// Get user key
+		var userKey = await GetUserKeyAsync(httpContext, serviceProvider);
         if (userKey == null)
         {
             _logger.LogTrace("User key not found.");

--- a/src/PermitMiddleware.cs
+++ b/src/PermitMiddleware.cs
@@ -60,8 +60,8 @@ public sealed class PermitMiddleware
         //With an intention to read request multiple times, enable buffering
         httpContext.Request.EnableBuffering();
 
-		// Get user key
-		var userKey = await GetUserKeyAsync(httpContext, serviceProvider);
+        // Get user key
+        var userKey = await GetUserKeyAsync(httpContext, serviceProvider);
         if (userKey == null)
         {
             _logger.LogTrace("User key not found.");

--- a/src/PermitSDK.AspNet.csproj
+++ b/src/PermitSDK.AspNet.csproj
@@ -10,9 +10,8 @@
         <Authors>Matteo Bortolazzo</Authors>
         <RepositoryUrl>https://github.com/permitio/permit-aspnet</RepositoryUrl>
 	    <Version>1.0.3</Version>
-	    <PackageReleaseNotes>Permit middleware - Fix PermitData - RequestFromBody</PackageReleaseNotes>
-
-        <PackageReadmeFile>README.md</PackageReadmeFile>
+	    <PackageReleaseNotes>Resource Key Instance-ResourceFromBody-Fix issue of request body not accessible post reading data from httpContext.Request.Body using a StreamReader</PackageReleaseNotes>
+	    <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
     

--- a/src/PermitSDK.AspNet.csproj
+++ b/src/PermitSDK.AspNet.csproj
@@ -9,8 +9,8 @@
         <WarningsAsErrors>$(WarningsAsErrors);1591</WarningsAsErrors>
         <Authors>Matteo Bortolazzo</Authors>
         <RepositoryUrl>https://github.com/permitio/permit-aspnet</RepositoryUrl>
-	    <Version>1.0.2</Version>
-	    <PackageReleaseNotes>Permit middleware - Fix single instance of ResourceInputBuilder</PackageReleaseNotes>
+	    <Version>1.0.3</Version>
+	    <PackageReleaseNotes>Permit middleware - Fix PermitData - RequestFromBody</PackageReleaseNotes>
 
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/ResourceInputBuilder.cs
+++ b/src/ResourceInputBuilder.cs
@@ -7,257 +7,257 @@ namespace PermitSDK.AspNet;
 
 internal class ResourceInputBuilder : IResourceInputBuilder
 {
-	private readonly PermitOptions _options;
-	private bool _isFailed;
-	private string? _resourceKey;
-	private string? _tenant;
-	private Dictionary<string, object>? _attributes;
-	private Dictionary<string, object>? _context;
+    private readonly PermitOptions _options;
+    private bool _isFailed;
+    private string? _resourceKey;
+    private string? _tenant;
+    private Dictionary<string, object>? _attributes;
+    private Dictionary<string, object>? _context;
 
-	private readonly IServiceProvider _serviceProvider;
+    private readonly IServiceProvider _serviceProvider;
 
-	public ResourceInputBuilder(
-		PermitOptions options,
-		IServiceProvider serviceProvider)
-	{
-		_options = options;
-		_serviceProvider = serviceProvider;
-		_tenant = options.UseDefaultTenantIfEmpty
-			? options.DefaultTenant
-			: null;
-	}
+    public ResourceInputBuilder(
+        PermitOptions options,
+        IServiceProvider serviceProvider)
+    {
+        _options = options;
+        _serviceProvider = serviceProvider;
+        _tenant = options.UseDefaultTenantIfEmpty
+            ? options.DefaultTenant
+            : null;
+    }
 
-	public async Task<Resource?> BuildAsync(IPermitData data, HttpContext httpContext)
-	{
-		await TryAppendResourceKeyAsync();
-		await TryAppendTenantAsync();
-		await TryAppendAttributesAsync();
-		await TryAppendContextAsync();
+    public async Task<Resource?> BuildAsync(IPermitData data, HttpContext httpContext)
+    {
+        await TryAppendResourceKeyAsync();
+        await TryAppendTenantAsync();
+        await TryAppendAttributesAsync();
+        await TryAppendContextAsync();
 
-		if (_isFailed)
-		{
-			return null;
-		}
+        if (_isFailed)
+        {
+            return null;
+        }
 
-		return new Resource(
-			_attributes,
-			_context,
-			_resourceKey,
-			_tenant,
-			data.ResourceType);
+        return new Resource(
+            _attributes,
+            _context,
+            _resourceKey,
+            _tenant,
+            data.ResourceType);
 
-		async Task TryAppendResourceKeyAsync()
-		{
-			var (isSpecified, resourceKey) = await GetValueAsync(
-				data.ResourceKey,
-				data.ResourceKeyFromRoute,
-				data.ResourceKeyFromHeader,
-				data.ResourceKeyFromQuery,
-				data.ResourceKeyFromClaim,
-				data.ResourceKeyFromBody,
-				data.ResourceKeyProviderType,
-				_options.GlobalResourceKeyProviderType);
+        async Task TryAppendResourceKeyAsync()
+        {
+            var (isSpecified, resourceKey) = await GetValueAsync(
+                data.ResourceKey,
+                data.ResourceKeyFromRoute,
+                data.ResourceKeyFromHeader,
+                data.ResourceKeyFromQuery,
+                data.ResourceKeyFromClaim,
+                data.ResourceKeyFromBody,
+                data.ResourceKeyProviderType,
+                _options.GlobalResourceKeyProviderType);
 
-			if (isSpecified && resourceKey == null)
-			{
-				_isFailed = true;
-			}
-			else if (resourceKey != null)
-			{
-				_resourceKey = resourceKey;
-			}
-		}
+            if (isSpecified && resourceKey == null)
+            {
+                _isFailed = true;
+            }
+            else if (resourceKey != null)
+            {
+                _resourceKey = resourceKey;
+            }
+        }
 
-		async Task TryAppendTenantAsync()
-		{
-			if (_isFailed)
-			{
-				return;
-			}
+        async Task TryAppendTenantAsync()
+        {
+            if (_isFailed)
+            {
+                return;
+            }
 
-			var (isSpecified, tenant) = await GetValueAsync(
-				data.Tenant,
-				data.TenantFromRoute,
-				data.TenantFromHeader,
-				data.TenantFromQuery,
-				data.TenantFromClaim,
-				data.TenantFromBody,
-				data.TenantProviderType,
-				_options.GlobalTenantProviderType);
+            var (isSpecified, tenant) = await GetValueAsync(
+                data.Tenant,
+                data.TenantFromRoute,
+                data.TenantFromHeader,
+                data.TenantFromQuery,
+                data.TenantFromClaim,
+                data.TenantFromBody,
+                data.TenantProviderType,
+                _options.GlobalTenantProviderType);
 
-			if (isSpecified && tenant == null)
-			{
-				_isFailed = true;
-			}
-			else if (tenant != null)
-			{
-				_tenant = tenant;
-			}
-		}
+            if (isSpecified && tenant == null)
+            {
+                _isFailed = true;
+            }
+            else if (tenant != null)
+            {
+                _tenant = tenant;
+            }
+        }
 
-		async Task<(bool IsSpecified, string? Value)> GetValueAsync(
-			string? staticValue,
-			string? fromRoute,
-			string? fromHeader,
-			string? fromQuery,
-			string? fromClaim,
-			string? fromBody,
-			Type? providerType,
-			Type? globalProviderType)
-		{
-			if (!string.IsNullOrWhiteSpace(staticValue))
-			{
-				return (true, staticValue);
-			}
+        async Task<(bool IsSpecified, string? Value)> GetValueAsync(
+            string? staticValue,
+            string? fromRoute,
+            string? fromHeader,
+            string? fromQuery,
+            string? fromClaim,
+            string? fromBody,
+            Type? providerType,
+            Type? globalProviderType)
+        {
+            if (!string.IsNullOrWhiteSpace(staticValue))
+            {
+                return (true, staticValue);
+            }
 
-			if (!string.IsNullOrWhiteSpace(fromRoute))
-			{
-				return (true, GetValueFromRoute(fromRoute));
-			}
+            if (!string.IsNullOrWhiteSpace(fromRoute))
+            {
+                return (true, GetValueFromRoute(fromRoute));
+            }
 
-			if (!string.IsNullOrWhiteSpace(fromHeader))
-			{
-				var value = GetValueFromHeader(fromHeader);
-				return (true, value);
-			}
+            if (!string.IsNullOrWhiteSpace(fromHeader))
+            {
+                var value = GetValueFromHeader(fromHeader);
+                return (true, value);
+            }
 
-			if (!string.IsNullOrWhiteSpace(fromQuery))
-			{
-				var value = GetValueFromQuery(fromQuery);
-				return (true, value);
-			}
+            if (!string.IsNullOrWhiteSpace(fromQuery))
+            {
+                var value = GetValueFromQuery(fromQuery);
+                return (true, value);
+            }
 
-			if (!string.IsNullOrWhiteSpace(fromClaim))
-			{
-				var value = GetValueFromClaim(fromClaim);
-				return (true, value);
-			}
+            if (!string.IsNullOrWhiteSpace(fromClaim))
+            {
+                var value = GetValueFromClaim(fromClaim);
+                return (true, value);
+            }
 
-			if (!string.IsNullOrWhiteSpace(fromBody))
-			{
-				return (true, await GetValueFromBody(fromBody));
-			}
+            if (!string.IsNullOrWhiteSpace(fromBody))
+            {
+                return (true, await GetValueFromBody(fromBody));
+            }
 
-			if (providerType != null)
-			{
-				var value = await _serviceProvider.GetProviderValue(httpContext, providerType);
-				return (true, value);
-			}
+            if (providerType != null)
+            {
+                var value = await _serviceProvider.GetProviderValue(httpContext, providerType);
+                return (true, value);
+            }
 
-			if (globalProviderType != null)
-			{
-				var value = await _serviceProvider.GetProviderValue(httpContext, globalProviderType);
-				return (true, value);
-			}
+            if (globalProviderType != null)
+            {
+                var value = await _serviceProvider.GetProviderValue(httpContext, globalProviderType);
+                return (true, value);
+            }
 
-			return (false, null);
-		}
+            return (false, null);
+        }
 
-		async Task TryAppendAttributesAsync()
-		{
-			if (_isFailed || (data.AttributesProviderType == null && _options.GlobalAttributesProviderType == null))
-			{
-				return;
-			}
+        async Task TryAppendAttributesAsync()
+        {
+            if (_isFailed || (data.AttributesProviderType == null && _options.GlobalAttributesProviderType == null))
+            {
+                return;
+            }
 
-			var providerType = data.AttributesProviderType ?? _options.GlobalAttributesProviderType;
-			var attributes = await _serviceProvider.GetProviderValues(httpContext, providerType!);
-			if (attributes == null)
-			{
-				_isFailed = true;
-			}
-			else
-			{
-				_attributes = attributes;
-			}
-		}
+            var providerType = data.AttributesProviderType ?? _options.GlobalAttributesProviderType;
+            var attributes = await _serviceProvider.GetProviderValues(httpContext, providerType!);
+            if (attributes == null)
+            {
+                _isFailed = true;
+            }
+            else
+            {
+                _attributes = attributes;
+            }
+        }
 
-		async Task TryAppendContextAsync()
-		{
-			if (_isFailed || (data.ContextProviderType == null && _options.GlobalContextProviderType == null))
-			{
-				return;
-			}
+        async Task TryAppendContextAsync()
+        {
+            if (_isFailed || (data.ContextProviderType == null && _options.GlobalContextProviderType == null))
+            {
+                return;
+            }
 
-			var providerType = data.ContextProviderType ?? _options.GlobalContextProviderType;
-			var context = await _serviceProvider.GetProviderValues(httpContext, providerType!);
-			if (context == null)
-			{
-				_isFailed = true;
-			}
-			else
-			{
-				_context = context;
-			}
-		}
+            var providerType = data.ContextProviderType ?? _options.GlobalContextProviderType;
+            var context = await _serviceProvider.GetProviderValues(httpContext, providerType!);
+            if (context == null)
+            {
+                _isFailed = true;
+            }
+            else
+            {
+                _context = context;
+            }
+        }
 
-		string? GetValueFromRoute(string routeName)
-		{
-			return httpContext.GetRouteValue(routeName)?.ToString();
-		}
+        string? GetValueFromRoute(string routeName)
+        {
+            return httpContext.GetRouteValue(routeName)?.ToString();
+        }
 
-		string? GetValueFromHeader(string headerName)
-		{
-			_ = httpContext.Request.Headers
-				.TryGetValue(headerName, out var value);
-			return value;
-		}
+        string? GetValueFromHeader(string headerName)
+        {
+            _ = httpContext.Request.Headers
+                .TryGetValue(headerName, out var value);
+            return value;
+        }
 
-		string? GetValueFromQuery(string queryParameter)
-		{
-			_ = httpContext.Request.Query
-				.TryGetValue(queryParameter, out var value);
-			return value;
-		}
+        string? GetValueFromQuery(string queryParameter)
+        {
+            _ = httpContext.Request.Query
+                .TryGetValue(queryParameter, out var value);
+            return value;
+        }
 
-		string? GetValueFromClaim(string claimType)
-		{
-			return httpContext.User.FindFirst(claimType)?.Value;
-		}
+        string? GetValueFromClaim(string claimType)
+        {
+            return httpContext.User.FindFirst(claimType)?.Value;
+        }
 
-		async Task<string?> GetValueFromBody(string jsonPropertyPath)
-		{
-			string requestBody;
+        async Task<string?> GetValueFromBody(string jsonPropertyPath)
+        {
+            string requestBody;
 
-			using (var reader = new StreamReader(httpContext.Request.Body, leaveOpen: true))
-			{
-				requestBody = await reader.ReadToEndAsync();
-				httpContext.Request.Body.Position = 0;
-			}
+            using (var reader = new StreamReader(httpContext.Request.Body, leaveOpen: true))
+            {
+                requestBody = await reader.ReadToEndAsync();
+                httpContext.Request.Body.Position = 0;
+            }
 
-			var jsonDocument = JsonDocument.Parse(requestBody);
-			var node = GetJsonElement(jsonDocument.RootElement, jsonPropertyPath);
-			return GetJsonElementValue(node);
-		}
+            var jsonDocument = JsonDocument.Parse(requestBody);
+            var node = GetJsonElement(jsonDocument.RootElement, jsonPropertyPath);
+            return GetJsonElementValue(node);
+        }
 
-		static JsonElement GetJsonElement(JsonElement jsonElement, string path)
-		{
-			if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
-			{
-				return default;
-			}
+        static JsonElement GetJsonElement(JsonElement jsonElement, string path)
+        {
+            if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            {
+                return default;
+            }
 
-			var segments = path.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
-			foreach (var t in segments)
-			{
-				jsonElement = jsonElement.TryGetProperty(t, out var value) ? value : default;
+            var segments = path.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var t in segments)
+            {
+                jsonElement = jsonElement.TryGetProperty(t, out var value) ? value : default;
 
-				if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
-				{
-					return default;
-				}
-			}
+                if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+                {
+                    return default;
+                }
+            }
 
-			return jsonElement;
-		}
+            return jsonElement;
+        }
 
-		static string? GetJsonElementValue(JsonElement jsonElement)
-		{
-			return
-				jsonElement.ValueKind != JsonValueKind.Null &&
-				jsonElement.ValueKind != JsonValueKind.Undefined ?
-					jsonElement.ToString() :
-					default;
-		}
-	}
+        static string? GetJsonElementValue(JsonElement jsonElement)
+        {
+            return
+                jsonElement.ValueKind != JsonValueKind.Null &&
+                jsonElement.ValueKind != JsonValueKind.Undefined
+                    ? jsonElement.ToString()
+                    : default;
+        }
+    }
 }

--- a/src/ResourceInputBuilder.cs
+++ b/src/ResourceInputBuilder.cs
@@ -7,255 +7,257 @@ namespace PermitSDK.AspNet;
 
 internal class ResourceInputBuilder : IResourceInputBuilder
 {
-    private readonly PermitOptions _options;
-    private bool _isFailed;
-    private string? _resourceKey;
-    private string? _tenant;
-    private Dictionary<string, object>? _attributes;
-    private Dictionary<string, object>? _context;
-    
-    private readonly IServiceProvider _serviceProvider;
+	private readonly PermitOptions _options;
+	private bool _isFailed;
+	private string? _resourceKey;
+	private string? _tenant;
+	private Dictionary<string, object>? _attributes;
+	private Dictionary<string, object>? _context;
 
-    public ResourceInputBuilder(
-        PermitOptions options,
-        IServiceProvider serviceProvider)
-    {
-        _options = options;
-        _serviceProvider = serviceProvider;
-        _tenant = options.UseDefaultTenantIfEmpty
-            ? options.DefaultTenant
-            : null;
-    }
+	private readonly IServiceProvider _serviceProvider;
 
-    public async Task<Resource?> BuildAsync(IPermitData data, HttpContext httpContext)
-    {
-        await TryAppendResourceKeyAsync();
-        await TryAppendTenantAsync();
-        await TryAppendAttributesAsync();
-        await TryAppendContextAsync();
+	public ResourceInputBuilder(
+		PermitOptions options,
+		IServiceProvider serviceProvider)
+	{
+		_options = options;
+		_serviceProvider = serviceProvider;
+		_tenant = options.UseDefaultTenantIfEmpty
+			? options.DefaultTenant
+			: null;
+	}
 
-        if (_isFailed)
-        {
-            return null;
-        }
+	public async Task<Resource?> BuildAsync(IPermitData data, HttpContext httpContext)
+	{
+		await TryAppendResourceKeyAsync();
+		await TryAppendTenantAsync();
+		await TryAppendAttributesAsync();
+		await TryAppendContextAsync();
 
-        return new Resource(
-            _attributes,
-            _context,
-            _resourceKey,
-            _tenant,
-            data.ResourceType);
+		if (_isFailed)
+		{
+			return null;
+		}
 
-        async Task TryAppendResourceKeyAsync()
-        {
-            var (isSpecified, resourceKey) = await GetValueAsync(
-                data.ResourceKey,
-                data.ResourceKeyFromRoute,
-                data.ResourceKeyFromHeader,
-                data.ResourceKeyFromQuery,
-                data.ResourceKeyFromClaim,
-                data.ResourceKeyFromBody,
-                data.ResourceKeyProviderType,
-                _options.GlobalResourceKeyProviderType);
+		return new Resource(
+			_attributes,
+			_context,
+			_resourceKey,
+			_tenant,
+			data.ResourceType);
 
-            if (isSpecified && resourceKey == null)
-            {
-                _isFailed = true;
-            }
-            else if (resourceKey != null)
-            {
-                _resourceKey = resourceKey;
-            }
-        }
+		async Task TryAppendResourceKeyAsync()
+		{
+			var (isSpecified, resourceKey) = await GetValueAsync(
+				data.ResourceKey,
+				data.ResourceKeyFromRoute,
+				data.ResourceKeyFromHeader,
+				data.ResourceKeyFromQuery,
+				data.ResourceKeyFromClaim,
+				data.ResourceKeyFromBody,
+				data.ResourceKeyProviderType,
+				_options.GlobalResourceKeyProviderType);
 
-        async Task TryAppendTenantAsync()
-        {
-            if (_isFailed)
-            {
-                return;
-            }
+			if (isSpecified && resourceKey == null)
+			{
+				_isFailed = true;
+			}
+			else if (resourceKey != null)
+			{
+				_resourceKey = resourceKey;
+			}
+		}
 
-            var (isSpecified, tenant) = await GetValueAsync(
-                data.Tenant,
-                data.TenantFromRoute,
-                data.TenantFromHeader,
-                data.TenantFromQuery,
-                data.TenantFromClaim,
-                data.TenantFromBody,
-                data.TenantProviderType,
-                _options.GlobalTenantProviderType);
+		async Task TryAppendTenantAsync()
+		{
+			if (_isFailed)
+			{
+				return;
+			}
 
-            if (isSpecified && tenant == null)
-            {
-                _isFailed = true;
-            }
-            else if (tenant != null)
-            {
-                _tenant = tenant;
-            }
-        }
+			var (isSpecified, tenant) = await GetValueAsync(
+				data.Tenant,
+				data.TenantFromRoute,
+				data.TenantFromHeader,
+				data.TenantFromQuery,
+				data.TenantFromClaim,
+				data.TenantFromBody,
+				data.TenantProviderType,
+				_options.GlobalTenantProviderType);
 
-        async Task<(bool IsSpecified, string? Value)> GetValueAsync(
-            string? staticValue,
-            string? fromRoute,
-            string? fromHeader,
-            string? fromQuery,
-            string? fromClaim,
-            string? fromBody,
-            Type? providerType,
-            Type? globalProviderType)
-        {
-            if (!string.IsNullOrWhiteSpace(staticValue))
-            {
-                return (true, staticValue);
-            }
+			if (isSpecified && tenant == null)
+			{
+				_isFailed = true;
+			}
+			else if (tenant != null)
+			{
+				_tenant = tenant;
+			}
+		}
 
-            if (!string.IsNullOrWhiteSpace(fromRoute))
-            {
-                return (true, GetValueFromRoute(fromRoute));
-            }
+		async Task<(bool IsSpecified, string? Value)> GetValueAsync(
+			string? staticValue,
+			string? fromRoute,
+			string? fromHeader,
+			string? fromQuery,
+			string? fromClaim,
+			string? fromBody,
+			Type? providerType,
+			Type? globalProviderType)
+		{
+			if (!string.IsNullOrWhiteSpace(staticValue))
+			{
+				return (true, staticValue);
+			}
 
-            if (!string.IsNullOrWhiteSpace(fromHeader))
-            {
-                var value = GetValueFromHeader(fromHeader);
-                return (true, value);
-            }
+			if (!string.IsNullOrWhiteSpace(fromRoute))
+			{
+				return (true, GetValueFromRoute(fromRoute));
+			}
 
-            if (!string.IsNullOrWhiteSpace(fromQuery))
-            {
-                var value = GetValueFromQuery(fromQuery);
-                return (true, value);
-            }
+			if (!string.IsNullOrWhiteSpace(fromHeader))
+			{
+				var value = GetValueFromHeader(fromHeader);
+				return (true, value);
+			}
 
-            if (!string.IsNullOrWhiteSpace(fromClaim))
-            {
-                var value = GetValueFromClaim(fromClaim);
-                return (true, value);
-            }
-            
-            if (!string.IsNullOrWhiteSpace(fromBody))
-            {
-                return (true, await GetValueFromBody(fromBody));
-            }
+			if (!string.IsNullOrWhiteSpace(fromQuery))
+			{
+				var value = GetValueFromQuery(fromQuery);
+				return (true, value);
+			}
 
-            if (providerType != null)
-            {
-                var value = await _serviceProvider.GetProviderValue(httpContext, providerType);
-                return (true, value);
-            }
+			if (!string.IsNullOrWhiteSpace(fromClaim))
+			{
+				var value = GetValueFromClaim(fromClaim);
+				return (true, value);
+			}
 
-            if (globalProviderType != null)
-            {
-                var value = await _serviceProvider.GetProviderValue(httpContext, globalProviderType);
-                return (true, value);
-            }
+			if (!string.IsNullOrWhiteSpace(fromBody))
+			{
+				return (true, await GetValueFromBody(fromBody));
+			}
 
-            return (false, null);
-        }
+			if (providerType != null)
+			{
+				var value = await _serviceProvider.GetProviderValue(httpContext, providerType);
+				return (true, value);
+			}
 
-        async Task TryAppendAttributesAsync()
-        {
-            if (_isFailed || (data.AttributesProviderType == null && _options.GlobalAttributesProviderType == null))
-            {
-                return;
-            }
+			if (globalProviderType != null)
+			{
+				var value = await _serviceProvider.GetProviderValue(httpContext, globalProviderType);
+				return (true, value);
+			}
 
-            var providerType = data.AttributesProviderType ?? _options.GlobalAttributesProviderType;
-            var attributes = await _serviceProvider.GetProviderValues(httpContext, providerType!);
-            if (attributes == null)
-            {
-                _isFailed = true;
-            }
-            else
-            {
-                _attributes = attributes;
-            }
-        }
+			return (false, null);
+		}
 
-        async Task TryAppendContextAsync()
-        {
-            if (_isFailed || (data.ContextProviderType == null && _options.GlobalContextProviderType == null))
-            {
-                return;
-            }
+		async Task TryAppendAttributesAsync()
+		{
+			if (_isFailed || (data.AttributesProviderType == null && _options.GlobalAttributesProviderType == null))
+			{
+				return;
+			}
 
-            var providerType = data.ContextProviderType ?? _options.GlobalContextProviderType;
-            var context = await _serviceProvider.GetProviderValues(httpContext, providerType!);
-            if (context == null)
-            {
-                _isFailed = true;
-            }
-            else
-            {
-                _context = context;
-            }
-        }
+			var providerType = data.AttributesProviderType ?? _options.GlobalAttributesProviderType;
+			var attributes = await _serviceProvider.GetProviderValues(httpContext, providerType!);
+			if (attributes == null)
+			{
+				_isFailed = true;
+			}
+			else
+			{
+				_attributes = attributes;
+			}
+		}
 
-        string? GetValueFromRoute(string routeName)
-        {
-            return httpContext.GetRouteValue(routeName)?.ToString();
-        }
+		async Task TryAppendContextAsync()
+		{
+			if (_isFailed || (data.ContextProviderType == null && _options.GlobalContextProviderType == null))
+			{
+				return;
+			}
 
-        string? GetValueFromHeader(string headerName)
-        {
-            _ = httpContext.Request.Headers
-                .TryGetValue(headerName, out var value);
-            return value;
-        }
+			var providerType = data.ContextProviderType ?? _options.GlobalContextProviderType;
+			var context = await _serviceProvider.GetProviderValues(httpContext, providerType!);
+			if (context == null)
+			{
+				_isFailed = true;
+			}
+			else
+			{
+				_context = context;
+			}
+		}
 
-        string? GetValueFromQuery(string queryParameter)
-        {
-            _ = httpContext.Request.Query
-                .TryGetValue(queryParameter, out var value);
-            return value;
-        }
+		string? GetValueFromRoute(string routeName)
+		{
+			return httpContext.GetRouteValue(routeName)?.ToString();
+		}
 
-        string? GetValueFromClaim(string claimType)
-        {
-            return httpContext.User.FindFirst(claimType)?.Value;
-        }
-        
-        async Task<string?> GetValueFromBody(string jsonPropertyPath)
-        {
-            string requestBody;
-            using (var reader = new StreamReader(httpContext.Request.Body))
-            {
-                requestBody = await reader.ReadToEndAsync();
-            }
+		string? GetValueFromHeader(string headerName)
+		{
+			_ = httpContext.Request.Headers
+				.TryGetValue(headerName, out var value);
+			return value;
+		}
 
-            var jsonDocument = JsonDocument.Parse(requestBody);
-            var node = GetJsonElement(jsonDocument.RootElement, jsonPropertyPath);
-            return GetJsonElementValue(node);
-        }
-        
-        static JsonElement GetJsonElement(JsonElement jsonElement, string path)
-        {
-            if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
-            {
-                return default;
-            }
+		string? GetValueFromQuery(string queryParameter)
+		{
+			_ = httpContext.Request.Query
+				.TryGetValue(queryParameter, out var value);
+			return value;
+		}
 
-            var segments = path.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var t in segments)
-            {
-                jsonElement = jsonElement.TryGetProperty(t, out var value) ? value : default;
+		string? GetValueFromClaim(string claimType)
+		{
+			return httpContext.User.FindFirst(claimType)?.Value;
+		}
 
-                if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
-                {
-                    return default;
-                }
-            }
+		async Task<string?> GetValueFromBody(string jsonPropertyPath)
+		{
+			string requestBody;
 
-            return jsonElement;
-        }
-        
-        static string? GetJsonElementValue(JsonElement jsonElement)
-        {
-            return
-                jsonElement.ValueKind != JsonValueKind.Null &&
-                jsonElement.ValueKind != JsonValueKind.Undefined ?
-                    jsonElement.ToString() :
-                    default;
-        } 
-    }
+			using (var reader = new StreamReader(httpContext.Request.Body, leaveOpen: true))
+			{
+				requestBody = await reader.ReadToEndAsync();
+				httpContext.Request.Body.Position = 0;
+			}
+
+			var jsonDocument = JsonDocument.Parse(requestBody);
+			var node = GetJsonElement(jsonDocument.RootElement, jsonPropertyPath);
+			return GetJsonElementValue(node);
+		}
+
+		static JsonElement GetJsonElement(JsonElement jsonElement, string path)
+		{
+			if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+			{
+				return default;
+			}
+
+			var segments = path.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+			foreach (var t in segments)
+			{
+				jsonElement = jsonElement.TryGetProperty(t, out var value) ? value : default;
+
+				if (jsonElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+				{
+					return default;
+				}
+			}
+
+			return jsonElement;
+		}
+
+		static string? GetJsonElementValue(JsonElement jsonElement)
+		{
+			return
+				jsonElement.ValueKind != JsonValueKind.Null &&
+				jsonElement.ValueKind != JsonValueKind.Undefined ?
+					jsonElement.ToString() :
+					default;
+		}
+	}
 }


### PR DESCRIPTION
**Flow :** API with resource key instance as "resourceFromBody".
**Issue :** Error from API as " request body could not be empty"
**RCA:** In resourceinputbuilder.cs , code snippet for reading the no element. Once the code execution moves beyond the using statement, the StreamReader is disposed, and any data read from the httpContext.Request.Body is no longer accessible. This is because the StreamReader is responsible for managing the underlying stream and closing it when it is disposed
**Fix:** The new code snippet  is responsible for reading the request body of an HTTP request and storing it in the requestBody variable. It uses a StreamReader to read the body content _and then sets the position of the request body stream back to the beginning_. The StreamReader is wrapped in a using statement, which ensures that the StreamReader is properly disposed of after it is no longer needed. Disposing of the StreamReader will also close the underlying stream (httpContext.Request.Body), preventing any potential resource leaks. Setting the position of the request body stream back to the beginning (httpContext.Request.Body.Position = 0) will allow subsequent code that may need to read the request.body to start from the beginning of the stream.