### PR TITLE
Add Callback before any request to PDP and fix issue while resolving the service for custom providers

### DIFF
--- a/src/InternalDelegatingHandler.cs
+++ b/src/InternalDelegatingHandler.cs
@@ -1,0 +1,20 @@
+﻿namespace PermitSDK.AspNet;
+
+internal class InternalDelegatingHandler : DelegatingHandler
+{
+	private readonly Func<HttpRequestMessage, Task> _configureRequest;
+
+	public InternalDelegatingHandler(Func<HttpRequestMessage, Task> configureRequest)
+	{
+		_configureRequest = configureRequest;
+	}
+
+	protected override async Task<HttpResponseMessage> SendAsync(
+		HttpRequestMessage request,
+		CancellationToken cancellationToken)
+	{
+		await _configureRequest(request);
+		var response = await base.SendAsync(request, cancellationToken);
+		return response;
+	}
+}

--- a/src/InternalDelegatingHandler.cs
+++ b/src/InternalDelegatingHandler.cs
@@ -2,19 +2,19 @@
 
 internal class InternalDelegatingHandler : DelegatingHandler
 {
-	private readonly Func<HttpRequestMessage, Task> _configureRequest;
+    private readonly Func<HttpRequestMessage, Task> _configureRequest;
 
-	public InternalDelegatingHandler(Func<HttpRequestMessage, Task> configureRequest)
-	{
-		_configureRequest = configureRequest;
-	}
+    public InternalDelegatingHandler(Func<HttpRequestMessage, Task> configureRequest)
+    {
+        _configureRequest = configureRequest;
+    }
 
-	protected override async Task<HttpResponseMessage> SendAsync(
-		HttpRequestMessage request,
-		CancellationToken cancellationToken)
-	{
-		await _configureRequest(request);
-		var response = await base.SendAsync(request, cancellationToken);
-		return response;
-	}
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        await _configureRequest(request);
+        var response = await base.SendAsync(request, cancellationToken);
+        return response;
+    }
 }

--- a/src/PermitExtensions.cs
+++ b/src/PermitExtensions.cs
@@ -83,19 +83,19 @@ public static class PermitExtensions
             pdp, resourceInputBuilderFactory, options, logger);
     }
 
-    internal static Task<User?> GetProviderUserKey(HttpContext httpContext, Type providerType)
+    internal static Task<User?> GetProviderUserKey(this HttpContext httpContext, Type providerType)
     {
         return RunProviderAsync<IPermitUserKeyProvider, User>(
             providerType, provider => provider.GetUserKeyAsync(httpContext), httpContext);
     }
 
-    internal static Task<string?> GetProviderValue(HttpContext httpContext, Type providerType)
-    {
-        return RunProviderAsync<IPermitValueProvider, string>(
-            providerType, provider => provider.GetValueAsync(httpContext), httpContext);
-    }
+	internal static Task<string?> GetProviderValue(this HttpContext httpContext, Type providerType)
+	{
+		return RunProviderAsync<IPermitValueProvider, string>(
+			providerType, provider => provider.GetValueAsync(httpContext), httpContext);
+	}
 
-    internal static Task<Dictionary<string, object>?> GetProviderValues(HttpContext httpContext, Type providerType)
+    internal static Task<Dictionary<string, object>?> GetProviderValues(this HttpContext httpContext, Type providerType)
     {
         return RunProviderAsync<IPermitValuesProvider, Dictionary<string, object>>(
             providerType, provider => provider.GetValues(httpContext), httpContext);

--- a/src/PermitExtensions.cs
+++ b/src/PermitExtensions.cs
@@ -48,21 +48,22 @@ public static class PermitExtensions
         }
 
         services
-	        .AddSingleton(options);
+            .AddSingleton(options);
 
         var httpClientBuilder = services.AddHttpClient<PdpService>(client =>
         {
-	        client.BaseAddress = new Uri(options.PdpUrl);
-	        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.ApiKey}");
-	        client.DefaultRequestHeaders.Add("x-permit-sdk-language", "permitio-aspnet-sdk");
+            client.BaseAddress = new Uri(options.PdpUrl);
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.ApiKey}");
+            client.DefaultRequestHeaders.Add("x-permit-sdk-language", "permitio-aspnet-sdk");
         });
 
         if (options.BeforeSendCallbackAsync != null)
         {
-	        httpClientBuilder.AddHttpMessageHandler(_ => new InternalDelegatingHandler(options.BeforeSendCallbackAsync));
+            httpClientBuilder.AddHttpMessageHandler(_ =>
+                new InternalDelegatingHandler(options.BeforeSendCallbackAsync));
         }
 
-		return services;
+        return services;
     }
 
     /// <summary>
@@ -95,11 +96,11 @@ public static class PermitExtensions
             providerType, provider => provider.GetUserKeyAsync(httpContext), httpContext);
     }
 
-	internal static Task<string?> GetProviderValue(this HttpContext httpContext, Type providerType)
-	{
-		return RunProviderAsync<IPermitValueProvider, string>(
-			providerType, provider => provider.GetValueAsync(httpContext), httpContext);
-	}
+    internal static Task<string?> GetProviderValue(this HttpContext httpContext, Type providerType)
+    {
+        return RunProviderAsync<IPermitValueProvider, string>(
+            providerType, provider => provider.GetValueAsync(httpContext), httpContext);
+    }
 
     internal static Task<Dictionary<string, object>?> GetProviderValues(this HttpContext httpContext, Type providerType)
     {

--- a/src/PermitMiddleware.cs
+++ b/src/PermitMiddleware.cs
@@ -61,7 +61,7 @@ public sealed class PermitMiddleware
         httpContext.Request.EnableBuffering();
 
         // Get user key
-        var userKey = await GetUserKeyAsync(httpContext, serviceProvider);
+        var userKey = await GetUserKeyAsync(httpContext);
         if (userKey == null)
         {
             _logger.LogTrace("User key not found.");
@@ -102,11 +102,11 @@ public sealed class PermitMiddleware
         return controllerAttributes.Concat(actionAttributes).ToArray();
     }
 
-    private async Task<User?> GetUserKeyAsync(HttpContext httpContext, IServiceProvider serviceProvider)
+    private async Task<User?> GetUserKeyAsync(HttpContext httpContext)
     {
         if (_options.GlobalUserKeyProviderType != null)
         {
-            return await serviceProvider.GetProviderUserKey(httpContext, _options.GlobalUserKeyProviderType);
+            return await PermitExtensions.GetProviderUserKey(httpContext, _options.GlobalUserKeyProviderType);
         }
 
         var userId = ExtractUserId(httpContext);

--- a/src/PermitMiddleware.cs
+++ b/src/PermitMiddleware.cs
@@ -106,7 +106,7 @@ public sealed class PermitMiddleware
     {
         if (_options.GlobalUserKeyProviderType != null)
         {
-            return await PermitExtensions.GetProviderUserKey(httpContext, _options.GlobalUserKeyProviderType);
+            return await httpContext.GetProviderUserKey(_options.GlobalUserKeyProviderType);
         }
 
         var userId = ExtractUserId(httpContext);

--- a/src/PermitOptions.cs
+++ b/src/PermitOptions.cs
@@ -53,4 +53,9 @@ public class PermitOptions
     /// Get or set the type of <see cref="IPermitUserKeyProvider"/> to use to get the user key
     /// </summary>
     public Type? GlobalUserKeyProviderType { get; set; }
+
+    /// <summary>
+    /// Function called before any request is sent to the PDP
+    /// </summary>
+    public Func<HttpRequestMessage, Task>? BeforeSendCallbackAsync { get; set; }
 }

--- a/src/PermitSDK.AspNet.csproj
+++ b/src/PermitSDK.AspNet.csproj
@@ -9,8 +9,8 @@
         <WarningsAsErrors>$(WarningsAsErrors);1591</WarningsAsErrors>
         <Authors>Matteo Bortolazzo</Authors>
         <RepositoryUrl>https://github.com/permitio/permit-aspnet</RepositoryUrl>
-        <Version>1.0.4</Version>
-        <PackageReleaseNotes>Fix Error while resolving the service for custom providers</PackageReleaseNotes>
+        <Version>1.1.0</Version>
+        <PackageReleaseNotes>Add Callback before any request to PDP and fix issue while resolving the service for custom providers</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>

--- a/src/PermitSDK.AspNet.csproj
+++ b/src/PermitSDK.AspNet.csproj
@@ -9,16 +9,16 @@
         <WarningsAsErrors>$(WarningsAsErrors);1591</WarningsAsErrors>
         <Authors>Matteo Bortolazzo</Authors>
         <RepositoryUrl>https://github.com/permitio/permit-aspnet</RepositoryUrl>
-	    <Version>1.0.3</Version>
-	    <PackageReleaseNotes>Resource Key Instance-ResourceFromBody-Fix issue of request body not accessible post reading data from httpContext.Request.Body using a StreamReader</PackageReleaseNotes>
-	    <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Version>1.0.4</Version>
+        <PackageReleaseNotes>Fix Error while resolving the service for custom providers</PackageReleaseNotes>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
-    
+
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     </ItemGroup>
-    
+
     <ItemGroup>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
         <None Include="..\LICENSE" Pack="true" PackagePath="\"/>

--- a/src/ResourceInputBuilder.cs
+++ b/src/ResourceInputBuilder.cs
@@ -136,13 +136,14 @@ internal class ResourceInputBuilder : IResourceInputBuilder
 
             if (providerType != null)
             {
-                var value = await PermitExtensions.GetProviderValue(httpContext, providerType);
+
+                var value = await httpContext.GetProviderValue(providerType);
                 return (true, value);
             }
 
             if (globalProviderType != null)
             {
-                var value = await PermitExtensions.GetProviderValue(httpContext, globalProviderType);
+                var value = await httpContext.GetProviderValue(globalProviderType);
                 return (true, value);
             }
 
@@ -157,7 +158,7 @@ internal class ResourceInputBuilder : IResourceInputBuilder
             }
 
             var providerType = data.AttributesProviderType ?? _options.GlobalAttributesProviderType;
-            var attributes = await PermitExtensions.GetProviderValues(httpContext, providerType!);
+            var attributes = await httpContext.GetProviderValues(providerType!);
             if (attributes == null)
             {
                 _isFailed = true;
@@ -176,7 +177,7 @@ internal class ResourceInputBuilder : IResourceInputBuilder
             }
 
             var providerType = data.ContextProviderType ?? _options.GlobalContextProviderType;
-            var context = await PermitExtensions.GetProviderValues(httpContext, providerType!);
+            var context = await httpContext.GetProviderValues(providerType!);
             if (context == null)
             {
                 _isFailed = true;

--- a/src/ResourceInputBuilder.cs
+++ b/src/ResourceInputBuilder.cs
@@ -136,7 +136,6 @@ internal class ResourceInputBuilder : IResourceInputBuilder
 
             if (providerType != null)
             {
-
                 var value = await httpContext.GetProviderValue(providerType);
                 return (true, value);
             }

--- a/src/ResourceInputBuilder.cs
+++ b/src/ResourceInputBuilder.cs
@@ -14,14 +14,10 @@ internal class ResourceInputBuilder : IResourceInputBuilder
     private Dictionary<string, object>? _attributes;
     private Dictionary<string, object>? _context;
 
-    private readonly IServiceProvider _serviceProvider;
-
     public ResourceInputBuilder(
-        PermitOptions options,
-        IServiceProvider serviceProvider)
+        PermitOptions options)
     {
         _options = options;
-        _serviceProvider = serviceProvider;
         _tenant = options.UseDefaultTenantIfEmpty
             ? options.DefaultTenant
             : null;
@@ -140,13 +136,13 @@ internal class ResourceInputBuilder : IResourceInputBuilder
 
             if (providerType != null)
             {
-                var value = await _serviceProvider.GetProviderValue(httpContext, providerType);
+                var value = await PermitExtensions.GetProviderValue(httpContext, providerType);
                 return (true, value);
             }
 
             if (globalProviderType != null)
             {
-                var value = await _serviceProvider.GetProviderValue(httpContext, globalProviderType);
+                var value = await PermitExtensions.GetProviderValue(httpContext, globalProviderType);
                 return (true, value);
             }
 
@@ -161,7 +157,7 @@ internal class ResourceInputBuilder : IResourceInputBuilder
             }
 
             var providerType = data.AttributesProviderType ?? _options.GlobalAttributesProviderType;
-            var attributes = await _serviceProvider.GetProviderValues(httpContext, providerType!);
+            var attributes = await PermitExtensions.GetProviderValues(httpContext, providerType!);
             if (attributes == null)
             {
                 _isFailed = true;
@@ -180,7 +176,7 @@ internal class ResourceInputBuilder : IResourceInputBuilder
             }
 
             var providerType = data.ContextProviderType ?? _options.GlobalContextProviderType;
-            var context = await _serviceProvider.GetProviderValues(httpContext, providerType!);
+            var context = await PermitExtensions.GetProviderValues(httpContext, providerType!);
             if (context == null)
             {
                 _isFailed = true;

--- a/tests/PermitSDK.AspNet.Tests/PermitSDK.AspNet.Tests.csproj
+++ b/tests/PermitSDK.AspNet.Tests/PermitSDK.AspNet.Tests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Moq" Version="4.18.4"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\PermitSDK.AspNet.csproj" />
+        <ProjectReference Include="..\..\src\PermitSDK.AspNet.csproj"/>
     </ItemGroup>
 
 

--- a/tests/PermitSDK.AspNet.Tests/ResourceInputBuilderTests.cs
+++ b/tests/PermitSDK.AspNet.Tests/ResourceInputBuilderTests.cs
@@ -14,10 +14,12 @@ public class ResourceInputBuilderTests
     private const string TestType = "testType";
     private const string TestResourceKey = "testKey";
     private const string TestTenant = "testTenant";
+
     private static readonly Dictionary<string, object> TestAttributes = new()
     {
         { "testAttrKey", "testAttrValue" }
     };
+
     private static readonly Dictionary<string, object> TestContext = new()
     {
         { "testCxtKey", "testCtxValue" }
@@ -35,10 +37,10 @@ public class ResourceInputBuilderTests
             ResourceKey = TestResourceKey
         };
         var httpContext = new DefaultHttpContext();
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
@@ -65,16 +67,16 @@ public class ResourceInputBuilderTests
         var featureCollection = new FeatureCollection();
         featureCollection.Set<IRouteValuesFeature>(endpointFeature);
         var httpContext = new DefaultHttpContext(featureCollection);
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestResourceKey, result.Key);
     }
-    
+
     [Fact]
     public async Task ResourceKey_FromHeader()
     {
@@ -95,16 +97,16 @@ public class ResourceInputBuilderTests
                 }
             }
         };
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestResourceKey, result.Key);
     }
-    
+
     [Fact]
     public async Task ResourceKey_FromBody()
     {
@@ -132,16 +134,16 @@ public class ResourceInputBuilderTests
                 Body = memoryStream
             }
         };
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestResourceKey, result.Key);
     }
-    
+
     [Fact]
     public async Task ResourceKey_Provider()
     {
@@ -152,56 +154,61 @@ public class ResourceInputBuilderTests
             ResourceKeyProviderType = typeof(ResourceKeyProvider)
         };
         var httpContext = new DefaultHttpContext();
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestResourceKey, result.Key);
     }
-    
+
     [Fact]
     public async Task ResourceKey_Provider_DependencyInjection()
     {
         // Arrange
-        var builder = GetBuilder(configureService: services => services
-            .AddSingleton<ResourceKeyProvider>()
-            .AddSingleton<ResourceKeyProviderDi>());
+        var builder = GetBuilder();
         var attribute = new PermitAttribute(TestAction, TestType)
         {
             ResourceKeyProviderType = typeof(ResourceKeyProviderDi)
         };
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<ResourceKeyProvider>()
+            .AddSingleton<ResourceKeyProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestResourceKey, result.Key);
     }
-    
+
     [Fact]
     public async Task ResourceKey_Provider_Global()
     {
         // Arrange
         var builder = GetBuilder(
-            options: new PermitOptions 
+            options: new PermitOptions
             {
                 GlobalResourceKeyProviderType = typeof(ResourceKeyProviderDi)
-            },
-            configureService: services => services
-                .AddSingleton<ResourceKeyProvider>()
-                .AddSingleton<ResourceKeyProviderDi>());
+            });
         var attribute = new PermitAttribute(TestAction, TestType);
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<ResourceKeyProvider>()
+            .AddSingleton<ResourceKeyProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
@@ -215,7 +222,7 @@ public class ResourceInputBuilderTests
             return Task.FromResult(TestResourceKey);
         }
     }
-    
+
     private class ResourceKeyProviderDi : IPermitValueProvider
     {
         private readonly ResourceKeyProvider _provider;
@@ -224,7 +231,7 @@ public class ResourceInputBuilderTests
         {
             _provider = provider;
         }
-        
+
         public Task<string> GetValueAsync(HttpContext httpContext)
         {
             return _provider.GetValueAsync(httpContext);
@@ -245,10 +252,10 @@ public class ResourceInputBuilderTests
             Tenant = TestTenant
         };
         var httpContext = new DefaultHttpContext();
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
@@ -275,16 +282,16 @@ public class ResourceInputBuilderTests
         var featureCollection = new FeatureCollection();
         featureCollection.Set<IRouteValuesFeature>(endpointFeature);
         var httpContext = new DefaultHttpContext(featureCollection);
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestTenant, result.Tenant);
     }
-    
+
     [Fact]
     public async Task Tenant_FromHeader()
     {
@@ -305,16 +312,16 @@ public class ResourceInputBuilderTests
                 }
             }
         };
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestTenant, result.Tenant);
     }
-    
+
     [Fact]
     public async Task Tenant_FromBody()
     {
@@ -342,16 +349,16 @@ public class ResourceInputBuilderTests
                 Body = memoryStream
             }
         };
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestTenant, result.Tenant);
     }
-    
+
     [Fact]
     public async Task Tenant_Provider()
     {
@@ -362,56 +369,60 @@ public class ResourceInputBuilderTests
             TenantProviderType = typeof(TenantProvider)
         };
         var httpContext = new DefaultHttpContext();
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestTenant, result.Tenant);
     }
-    
+
     [Fact]
     public async Task Tenant_Provider_DependencyInjection()
     {
         // Arrange
-        var builder = GetBuilder(configureService: services => services
-            .AddSingleton<TenantProvider>()
-            .AddSingleton<TenantProviderDi>());
+        var builder = GetBuilder();
         var attribute = new PermitAttribute(TestAction, TestType)
         {
             TenantProviderType = typeof(TenantProviderDi)
         };
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<TenantProvider>()
+            .AddSingleton<TenantProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestTenant, result.Tenant);
     }
-    
+
     [Fact]
     public async Task Tenant_Provider_Global()
     {
         // Arrange
         var builder = GetBuilder(
-            options: new PermitOptions 
+            options: new PermitOptions
             {
                 GlobalTenantProviderType = typeof(TenantProviderDi)
-            },
-            configureService: services => services
-                .AddSingleton<TenantProvider>()
-                .AddSingleton<TenantProviderDi>());
+            });
         var attribute = new PermitAttribute(TestAction, TestType);
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<TenantProvider>()
+            .AddSingleton<TenantProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
@@ -425,7 +436,7 @@ public class ResourceInputBuilderTests
             return Task.FromResult(TestTenant);
         }
     }
-    
+
     private class TenantProviderDi : IPermitValueProvider
     {
         private readonly TenantProvider _provider;
@@ -434,7 +445,7 @@ public class ResourceInputBuilderTests
         {
             _provider = provider;
         }
-        
+
         public Task<string> GetValueAsync(HttpContext httpContext)
         {
             return _provider.GetValueAsync(httpContext);
@@ -455,56 +466,61 @@ public class ResourceInputBuilderTests
             AttributesProviderType = typeof(AttributesProvider)
         };
         var httpContext = new DefaultHttpContext();
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestAttributes, result.Attributes);
     }
-    
+
     [Fact]
     public async Task Attributes_Provider_DependencyInjection()
     {
         // Arrange
-        var builder = GetBuilder(configureService: services => services
-            .AddSingleton<AttributesProvider>()
-            .AddSingleton<AttributesProviderDi>());
+        var builder = GetBuilder();
         var attribute = new PermitAttribute(TestAction, TestType)
         {
             AttributesProviderType = typeof(AttributesProviderDi)
         };
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<AttributesProvider>()
+            .AddSingleton<AttributesProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestAttributes, result.Attributes);
     }
-    
+
     [Fact]
     public async Task Attributes_Provider_Global()
     {
         // Arrange
         var builder = GetBuilder(
-            options: new PermitOptions 
+            options: new PermitOptions
             {
                 GlobalAttributesProviderType = typeof(AttributesProviderDi)
-            },
-            configureService: services => services
-                .AddSingleton<AttributesProvider>()
-                .AddSingleton<AttributesProviderDi>());
+            });
         var attribute = new PermitAttribute(TestAction, TestType);
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<AttributesProvider>()
+            .AddSingleton<AttributesProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
@@ -518,7 +534,7 @@ public class ResourceInputBuilderTests
             return Task.FromResult(TestAttributes);
         }
     }
-    
+
     private class AttributesProviderDi : IPermitValuesProvider
     {
         private readonly AttributesProvider _provider;
@@ -535,7 +551,7 @@ public class ResourceInputBuilderTests
     }
 
     #endregion
-    
+
     #region Context
 
     [Fact]
@@ -548,56 +564,61 @@ public class ResourceInputBuilderTests
             ContextProviderType = typeof(ContextProvider)
         };
         var httpContext = new DefaultHttpContext();
-        
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestContext, result.Context);
     }
-    
+
     [Fact]
     public async Task Context_Provider_DependencyInjection()
     {
         // Arrange
-        var builder = GetBuilder(configureService: services => services
-            .AddSingleton<ContextProvider>()
-            .AddSingleton<ContextProviderDi>());
+        var builder = GetBuilder();
         var attribute = new PermitAttribute(TestAction, TestType)
         {
             ContextProviderType = typeof(ContextProviderDi)
         };
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<ContextProvider>()
+            .AddSingleton<ContextProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
         Assert.Equal(TestContext, result.Context);
     }
-    
+
     [Fact]
     public async Task Context_Provider_Global()
     {
         // Arrange
         var builder = GetBuilder(
-            options: new PermitOptions 
+            options: new PermitOptions
             {
                 GlobalContextProviderType = typeof(ContextProviderDi)
-            },
-            configureService: services => services
-                .AddSingleton<ContextProvider>()
-                .AddSingleton<ContextProviderDi>());
+            });
         var attribute = new PermitAttribute(TestAction, TestType);
         var httpContext = new DefaultHttpContext();
-        
+
+        var configureService = new Action<ServiceCollection>(services => services
+            .AddSingleton<ContextProvider>()
+            .AddSingleton<ContextProviderDi>());
+        httpContext.RequestServices = BuildServiceProvider(configureService);
+
         // Act
         var result = await builder.BuildAsync(attribute, httpContext);
-        
+
         // Assert
         Assert.NotNull(result);
         Assert.Equal(TestType, result.Type);
@@ -611,7 +632,7 @@ public class ResourceInputBuilderTests
             return Task.FromResult(TestContext);
         }
     }
-    
+
     private class ContextProviderDi : IPermitValuesProvider
     {
         private readonly ContextProvider _provider;
@@ -628,17 +649,21 @@ public class ResourceInputBuilderTests
     }
 
     #endregion
-    
+
     #region Helpers
 
     private static ResourceInputBuilder GetBuilder(
-        PermitOptions? options = null,
-        Action<ServiceCollection>? configureService = null)
+        PermitOptions? options = null)
     {
         options ??= new PermitOptions();
+        return new ResourceInputBuilder(options);
+    }
+
+    private static IServiceProvider BuildServiceProvider(Action<ServiceCollection>? configureService = null)
+    {
         var services = new ServiceCollection();
         configureService?.Invoke(services);
-        return new ResourceInputBuilder(options, services.BuildServiceProvider());
+        return services.BuildServiceProvider();
     }
 
     #endregion


### PR DESCRIPTION
Fix issue while resolving the service for custom providers

**Flow** : custom providers flow
**Issue :** Getting error as "Cannot resolve scoped service from root provider."
**RCA:** This error is coming while resolving the service . Now since the service is scoped which is once per client request
and we are resolving it using ServiceProvider which is a reference to applications root container , which may not be correct for current request (context)
i.e why I used httpcontext.requestservices to retrieve the service instance , which ensures that the service is scoped to the currrent request
**FIX :**  use httpcontext.requestservices instead of ServiceProvider 